### PR TITLE
Store as struct / Unexpected boilerplate cleanup(Only 3 lines!)

### DIFF
--- a/Flux/Store.swift
+++ b/Flux/Store.swift
@@ -1,15 +1,18 @@
-public class Store<ObservableState: ObservablePropertyType> {
-    public var state: ObservableState
+public protocol StoreType {
+    typealias ObservableState: ObservablePropertyType
 
-    public init(state: ObservableState) {
-        self.state = state
+    var state: ObservableState { get set }
+
+    mutating func dispatch<A: ActionType where A.StateValueType == ObservableState.ValueType>(action: A)
+    func dispatch<A: AsyncActionType>(action: A) -> A.ResponseType
+}
+
+public extension StoreType {
+    public mutating func dispatch<A: ActionType where A.StateValueType == ObservableState.ValueType>(action: A) {
+        state.value = action.reduce(state.value)
     }
 
-    public func dispatch<A: ActionType where A.StateValueType == ObservableState.ValueType>(action: A) {
-        self.state.value = action.reduce(self.state.value)
-    }
-
-    public func dispatch<A: AsyncActionType>(action: A) -> A.ResponseType {
+    public func dispatch<A : AsyncActionType>(action: A) -> A.ResponseType {
         return action.call()
     }
 }

--- a/FluxTests/FluxSetup.swift
+++ b/FluxTests/FluxSetup.swift
@@ -5,16 +5,8 @@ struct AppState {
     let users: ObservableProperty<[User]> = ObservableProperty(value: [])
 }
 
-protocol Action: ActionType {
-    typealias StateValueType = AppState
-}
-
-protocol AsyncAction: AsyncActionType { }
-
-class Store: Flux.Store<ObservableProperty<AppState>> {
-    init(state: AppState) {
-        super.init(state: ObservableProperty(value: state))
-    }
+struct Store: StoreType {
+    var state: ObservableProperty<AppState>
 }
 
 // MARK: Getters

--- a/FluxTests/FluxTests.swift
+++ b/FluxTests/FluxTests.swift
@@ -6,7 +6,8 @@ var store: Store!
 class FluxTests: XCTestCase {
     override func setUp() {
         super.setUp()
-        store = Store(state: AppState())
+        let initialState = ObservableProperty(value: AppState())
+        store = Store(state: initialState)
     }
 
     func testDispatchAction() {

--- a/FluxTests/TestActions.swift
+++ b/FluxTests/TestActions.swift
@@ -1,6 +1,6 @@
 @testable import Flux
 
-struct SetCurrentUserAction: Action {
+struct SetCurrentUserAction: ActionType {
     let user: User
 
     func reduce(state: AppState) -> AppState {
@@ -9,7 +9,7 @@ struct SetCurrentUserAction: Action {
     }
 }
 
-struct SetUsersAction: Action {
+struct SetUsersAction: ActionType {
     let users: [User]
 
     func reduce(state: AppState) -> AppState {
@@ -18,7 +18,7 @@ struct SetUsersAction: Action {
     }
 }
 
-struct FetchUsersAction: AsyncAction {
+struct FetchUsersAction: AsyncActionType {
     typealias ResponseType = Void
 
     let usersToReturn: [User]


### PR DESCRIPTION
Why:
- Store class syntax was a bit gross and protocol extensions!
- Too much boilerplate #4 

This change addresses the need by:
- Adding a `StoreType` that you implement on a store struct. It contains default
  implementations for dispatching.
- Randomly come across the fact that implementing the `reduce` method on the
  `ActionType` infers the typealias

The only required setup you need now is:

``` swift
struct Store: StoreType {
    var state: ObservableProperty<AppState>
}
```

Edits: Changed setup to remove redundant typealias
