### PR TITLE
Remove value label from ObservableProperty call.

### DIFF
--- a/Flux/ObservableProperty.swift
+++ b/Flux/ObservableProperty.swift
@@ -18,7 +18,7 @@ public class ObservableProperty<ValueType> {
         }
     }
 
-    public init(value: ValueType) {
+    public init(_ value: ValueType) {
         self._value = value
     }
 

--- a/FluxTests/FluxSetup.swift
+++ b/FluxTests/FluxSetup.swift
@@ -1,8 +1,8 @@
 @testable import Flux
 
 struct AppState {
-    let currentUser: ObservableProperty<User?> = ObservableProperty(value: .None)
-    let users: ObservableProperty<[User]> = ObservableProperty(value: [])
+    let currentUser = ObservableProperty<User?>(.None)
+    let users = ObservableProperty<[User]>([])
 }
 
 struct Store: StoreType {

--- a/FluxTests/ObservablePropertyTests.swift
+++ b/FluxTests/ObservablePropertyTests.swift
@@ -6,16 +6,14 @@ class ObservablePropertyTests: QuickSpec {
     override func spec() {
         describe("ObservableProperty") {
             it("is initialized with a value") {
-                let value = 1
+                let property = ObservableProperty(1)
                 
-                let property = ObservableProperty(value: value)
-                
-                expect(property.value).to(equal(value))
+                expect(property.value).to(equal(1))
             }
             
             describe("subscriptions") {
                 it("calls subscriptions when value changes") {
-                    let property = ObservableProperty(value: 1)
+                    let property = ObservableProperty(1)
                     
                     var called = 0
                     property.subscribe { _ in called++ }

--- a/FluxTests/StoreTests.swift
+++ b/FluxTests/StoreTests.swift
@@ -9,7 +9,7 @@ class StoreTests: QuickSpec {
         describe("Store") {
             describe(".dispatch") {
                 beforeEach() {
-                    let initialState = ObservableProperty(value: AppState())
+                    let initialState = ObservableProperty(AppState())
                     store = Store(state: initialState)
                 }
                 


### PR DESCRIPTION
Mimics other apis like `Variable` from RxSwift or `MutableProperty` from RAC. It
also doesn't add any value to the user to have to type it.
