### PR TITLE
[wip] Middleware

### DIFF
--- a/Delta.xcodeproj/project.pbxproj
+++ b/Delta.xcodeproj/project.pbxproj
@@ -127,7 +127,9 @@
 				E7ACEA6E1BF62BD50045CA6A /* Tests */,
 				E7ACEA611BF62BD40045CA6A /* Products */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
 		};
 		E7ACEA611BF62BD40045CA6A /* Products */ = {
 			isa = PBXGroup;

--- a/Tests/Setup/Store.swift
+++ b/Tests/Setup/Store.swift
@@ -5,12 +5,8 @@ struct AppState {
     let users = ObservableProperty<[User]>([])
 }
 
-struct Store: StoreType {
-    var state: ObservableProperty<AppState>
-}
-
 // MARK: Getters
-extension Store {
+extension Store where ObservableState.ValueType == AppState {
     var currentUser: User? {
         return state.value.currentUser.value
     }

--- a/Tests/Tests/StoreSpec.swift
+++ b/Tests/Tests/StoreSpec.swift
@@ -2,7 +2,7 @@ import Quick
 import Nimble
 import Delta
 
-var store: Store!
+var store: Store<ObservableProperty<AppState>>!
 
 class StoreSpec: QuickSpec {
     override func spec() {
@@ -12,7 +12,7 @@ class StoreSpec: QuickSpec {
                     let initialState = ObservableProperty(AppState())
                     store = Store(state: initialState)
                 }
-                
+
                 it("triggers action") {
                     let user = User(name: "Jane Doe")
                     
@@ -20,7 +20,7 @@ class StoreSpec: QuickSpec {
                     
                     expect(store.currentUser).to(equal(user))
                 }
-                
+
                 it("triggers async action") {
                     let usersToReturn = [User(name: "Jane Doe"), User(name: "John Doe")]
                     
@@ -28,6 +28,23 @@ class StoreSpec: QuickSpec {
                     store.dispatch(action)
                     
                     expect(store.users).toEventually(equal(usersToReturn))
+                }
+
+                it("executes middleware") {
+                    var executed = false
+
+                    store.register { state, next -> Bool in
+                        executed = true
+
+                        return next()
+                    }
+
+                    let user = User(name: "Jane Doe")
+                    let action = SetCurrentUserAction(user: user)
+                    store.dispatch(action)
+
+                    expect(store.state.value.currentUser.value).to(equal(user))
+                    expect(executed).to(beTrue())
                 }
             }
         }


### PR DESCRIPTION
Another attempt at middleware. I had to make `Store` its own concrete structure so it could store currently registered middleware. Maybe it makes more sense as a final class.

A `Middleware` is a function that takes the current state value `stateValue`, and a `() -> Bool` function `next`.

Middleware is executed sequentially in the order it is registered. The next middleware is only executed if the previous returns the result of `next()` at the end. If it returns `false`, the state will not be updated. If it returns `true`, the state will be updated immediately without executing the remaining middleware.

See the `StoreSpec` for a super basic example.
## 

I still don't think this is the final route to go, but I think I'm getting closer. Ideally, Middleware would also take the `action` being dispatched. But unfortunately that's not currently possible because we can't add generic constraints to a `typealias` (currently `Middleware` is just a type alias). I think there's a way to get around this, but I haven't cracked that yet. Going to keep fiddling.
## 

Tracking changes aka time travel debugging #19 will be difficult. Because Swift doesn't have higher order types, there's no way to store a collection of type-constrained, protocol conforming structures of different types. In other words, even though the `reduce` for every `ActionType` associated with a particular store has the same signature, the structures themselves have different types, so they can't be stored side-by-side in a collection.

One way we might be able to get around this and still have valuable information about mutation is by reflecting the action and initializing a `Mutation` structure, containing the stringified action type (e.g. `"SetCurrentUserAction"`) and that actions stored properties (e.g. `["user": User(name: "Jane Doe")]`). This would give us the same valuable information and we'd be able to store these concrete `Mutation`s easily
