### PR TITLE
Rename protocols to match Swift naming guidelines

### DIFF
--- a/Delta.xcodeproj/project.pbxproj
+++ b/Delta.xcodeproj/project.pbxproj
@@ -12,7 +12,6 @@
 		089B593C1C163FA600840D9F /* Store.swift in Sources */ = {isa = PBXBuildFile; fileRef = 089B59391C163FA600840D9F /* Store.swift */; };
 		089B593F1C163FC000840D9F /* ObservablePropertySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 089B593D1C163FC000840D9F /* ObservablePropertySpec.swift */; };
 		089B59401C163FC000840D9F /* StoreSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 089B593E1C163FC000840D9F /* StoreSpec.swift */; };
-		089B59451C1642C900840D9F /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 089B59441C1642C900840D9F /* Info.plist */; };
 		E799CF091BFE218600E751E5 /* ObservableProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = E799CF081BFE218600E751E5 /* ObservableProperty.swift */; };
 		E799CF1A1C05FD6100E751E5 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E799CF191C05FD6100E751E5 /* Nimble.framework */; };
 		E799CF1C1C05FD6E00E751E5 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E799CF1B1C05FD6E00E751E5 /* Quick.framework */; };
@@ -262,7 +261,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				089B59451C1642C900840D9F /* Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Action.swift
+++ b/Sources/Action.swift
@@ -17,7 +17,7 @@
  store.dispatch(UpdateIdAction(id: 1))
  ```
 */
-public protocol ActionType {
+public protocol Action {
     /**
      The type of the app's state.
 

--- a/Sources/DynamicAction.swift
+++ b/Sources/DynamicAction.swift
@@ -18,7 +18,7 @@
  store.dispatch(UpdateIdAction(id: 1))
  ```
 */
-public protocol DynamicActionType {
+public protocol DynamicAction {
     /**
      The return type from the `call` method.
 

--- a/Sources/ObservableProperty.swift
+++ b/Sources/ObservableProperty.swift
@@ -6,7 +6,7 @@
  This is useful if you want to plug in a reactive programming library and use
  that for state instead of the built-in ObservableProperty type.
 */
-public protocol ObservablePropertyType {
+public protocol Observable {
     /**
      The type of the value that `Self` will hold.
 
@@ -81,4 +81,4 @@ public class ObservableProperty<ValueType> {
     }
 }
 
-extension ObservableProperty: ObservablePropertyType { }
+extension ObservableProperty: Observable { }

--- a/Sources/Store.swift
+++ b/Sources/Store.swift
@@ -19,12 +19,12 @@
  var store = Store(state: ObservableProperty(initialState))
  ```
 */
-public protocol StoreType {
+public protocol Store {
     /**
      An observable state of the store. This is accessed directly to subscribe to
      changes.
     */
-    typealias ObservableState: ObservablePropertyType
+    typealias ObservableState: Observable
 
     /**
      The type of the root state of the application.
@@ -36,28 +36,28 @@ public protocol StoreType {
     /**
      Dispatch an action that will mutate the state of the store.
     */
-    mutating func dispatch<Action: ActionType where Action.StateValueType == ObservableState.ValueType>(action: Action)
+    mutating func dispatch<A: Action where A.StateValueType == ObservableState.ValueType>(action: A)
 
     /**
      Dispatch an async action that when called should trigger another dispatch
      with a synchronous action.
     */
-    func dispatch<DynamicAction: DynamicActionType>(action: DynamicAction) -> DynamicAction.ResponseType
+    func dispatch<D: DynamicAction>(action: D) -> D.ResponseType
 }
 
-public extension StoreType {
+public extension Store {
     /**
       Dispatches an action by settings the state's value to the result of
       calling it's `reduce` method.
     */
-    public mutating func dispatch<Action: ActionType where Action.StateValueType == ObservableState.ValueType>(action: Action) {
+    public mutating func dispatch<A: Action where A.StateValueType == ObservableState.ValueType>(action: A) {
         state.value = action.reduce(state.value)
     }
 
     /**
       Dispatches an async action by calling it's `call` method.
     */
-    public func dispatch<DynamicAction: DynamicActionType>(action: DynamicAction) -> DynamicAction.ResponseType {
+    public func dispatch<D: DynamicAction>(action: D) -> D.ResponseType {
         return action.call()
     }
 }

--- a/Tests/Setup/Actions.swift
+++ b/Tests/Setup/Actions.swift
@@ -1,6 +1,6 @@
 import Delta
 
-struct SetCurrentUserAction: ActionType {
+struct SetCurrentUserAction: Action {
     let user: User
 
     func reduce(state: AppState) -> AppState {
@@ -9,7 +9,7 @@ struct SetCurrentUserAction: ActionType {
     }
 }
 
-struct SetUsersAction: ActionType {
+struct SetUsersAction: Action {
     let users: [User]
 
     func reduce(state: AppState) -> AppState {
@@ -18,7 +18,7 @@ struct SetUsersAction: ActionType {
     }
 }
 
-struct FetchUsersAction: DynamicActionType {
+struct FetchUsersAction: DynamicAction {
     typealias ResponseType = Void
 
     let usersToReturn: [User]

--- a/Tests/Setup/Store.swift
+++ b/Tests/Setup/Store.swift
@@ -5,12 +5,12 @@ struct AppState {
     let users = ObservableProperty<[User]>([])
 }
 
-struct Store: StoreType {
+struct AppStore: Store {
     var state: ObservableProperty<AppState>
 }
 
 // MARK: Getters
-extension Store {
+extension AppStore {
     var currentUser: User? {
         return state.value.currentUser.value
     }
@@ -19,3 +19,5 @@ extension Store {
         return state.value.users.value
     }
 }
+
+var store: AppStore!

--- a/Tests/Tests/StoreSpec.swift
+++ b/Tests/Tests/StoreSpec.swift
@@ -2,15 +2,13 @@ import Quick
 import Nimble
 import Delta
 
-var store: Store!
-
 class StoreSpec: QuickSpec {
     override func spec() {
         describe("Store") {
             describe(".dispatch") {
                 beforeEach() {
                     let initialState = ObservableProperty(AppState())
-                    store = Store(state: initialState)
+                    store = AppStore(state: initialState)
                 }
                 
                 it("triggers action") {


### PR DESCRIPTION
First pass at #22 
