### PR TITLE
Update for swift 4.0 and change the scan tools to fastlane scan

### DIFF
--- a/Delta.xcodeproj/project.pbxproj
+++ b/Delta.xcodeproj/project.pbxproj
@@ -12,7 +12,6 @@
 		089B593C1C163FA600840D9F /* Store.swift in Sources */ = {isa = PBXBuildFile; fileRef = 089B59391C163FA600840D9F /* Store.swift */; };
 		089B593F1C163FC000840D9F /* ObservablePropertySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 089B593D1C163FC000840D9F /* ObservablePropertySpec.swift */; };
 		089B59401C163FC000840D9F /* StoreSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 089B593E1C163FC000840D9F /* StoreSpec.swift */; };
-		089B59451C1642C900840D9F /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 089B59441C1642C900840D9F /* Info.plist */; };
 		E799CF091BFE218600E751E5 /* ObservableProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = E799CF081BFE218600E751E5 /* ObservableProperty.swift */; };
 		E799CF1A1C05FD6100E751E5 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E799CF191C05FD6100E751E5 /* Nimble.framework */; };
 		E799CF1C1C05FD6E00E751E5 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E799CF1B1C05FD6E00E751E5 /* Quick.framework */; };
@@ -221,7 +220,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0710;
-				LastUpgradeCheck = 0710;
+				LastUpgradeCheck = 0920;
 				ORGANIZATIONNAME = thoughtbot;
 				TargetAttributes = {
 					E7ACEA5F1BF62BD40045CA6A = {
@@ -262,7 +261,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				089B59451C1642C900840D9F /* Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -312,13 +310,21 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -360,13 +366,21 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -386,6 +400,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -398,7 +413,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -411,6 +426,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -419,7 +435,7 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -431,12 +447,14 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.thoughtbot.Delta;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
 		E7ACEA781BF62BD50045CA6A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.thoughtbot.DeltaTests;
@@ -447,6 +465,7 @@
 		E7ACEA791BF62BD50045CA6A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.thoughtbot.DeltaTests;

--- a/Delta.xcodeproj/project.pbxproj
+++ b/Delta.xcodeproj/project.pbxproj
@@ -352,6 +352,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -401,6 +402,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/Delta.xcodeproj/xcshareddata/xcschemes/Delta.xcscheme
+++ b/Delta.xcodeproj/xcshareddata/xcschemes/Delta.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -55,6 +56,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "scan"
+gem "fastlane"

--- a/Sources/Action.swift
+++ b/Sources/Action.swift
@@ -23,7 +23,7 @@ public protocol ActionType {
 
      - note: This is inferred from the `reduce` method implementation.
     */
-    typealias StateValueType
+    associatedtype StateValueType
 
     /**
      This method is called when this action is dispatched. Its purpose is to

--- a/Sources/DynamicAction.swift
+++ b/Sources/DynamicAction.swift
@@ -24,7 +24,7 @@ public protocol DynamicActionType {
 
      - note: This is inferred from the `call` method implementation.
     */
-    typealias ResponseType
+    associatedtype ResponseType
 
     /**
      This method is where you perform some async behavior that when completed,

--- a/Sources/ObservableProperty.swift
+++ b/Sources/ObservableProperty.swift
@@ -12,7 +12,7 @@ public protocol ObservablePropertyType {
 
      - note: This is inferred from the `value` property implementation.
     */
-    typealias ValueType
+    associatedtype ValueType
 
     /**
      The value to be observed and mutated.
@@ -44,7 +44,7 @@ public class ObservableProperty<ValueType> {
     /**
      The type of the callback to be called when the `value` changes.
     */
-    public typealias CallbackType = (ValueType -> ())
+    public typealias CallbackType = ((ValueType) -> ())
 
     private var subscriptions = [CallbackType]()
 
@@ -70,7 +70,7 @@ public class ObservableProperty<ValueType> {
 
       - parameter callback: The function to call when the value changes.
     */
-    public func subscribe(callback: CallbackType) {
+    public func subscribe(callback: @escaping CallbackType) {
         subscriptions.append(callback)
     }
 

--- a/Sources/Store.swift
+++ b/Sources/Store.swift
@@ -24,7 +24,7 @@ public protocol StoreType {
      An observable state of the store. This is accessed directly to subscribe to
      changes.
     */
-    typealias ObservableState: ObservablePropertyType
+    associatedtype ObservableState: ObservablePropertyType
 
     /**
      The type of the root state of the application.
@@ -36,7 +36,7 @@ public protocol StoreType {
     /**
      Dispatch an action that will mutate the state of the store.
     */
-    mutating func dispatch<Action: ActionType where Action.StateValueType == ObservableState.ValueType>(action: Action)
+    mutating func dispatch<Action: ActionType>(action: Action) where Action.StateValueType == ObservableState.ValueType
 
     /**
      Dispatch an async action that when called should trigger another dispatch
@@ -50,8 +50,8 @@ public extension StoreType {
       Dispatches an action by settings the state's value to the result of
       calling it's `reduce` method.
     */
-    public mutating func dispatch<Action: ActionType where Action.StateValueType == ObservableState.ValueType>(action: Action) {
-        state.value = action.reduce(state.value)
+    public mutating func dispatch<Action: ActionType>(action: Action) where Action.StateValueType == ObservableState.ValueType {
+        state.value = action.reduce(state: state.value)
     }
 
     /**

--- a/bin/test
+++ b/bin/test
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-scan
+fastlane scan


### PR DESCRIPTION
scan tools has been integrated into the fastlane project so can not be installed by gem install scan
and swfit 4.0 has some subtle change in protocol associate type, the test tools have not support swift 4.0 compiler, so the test cases not be run successfully. Maybe you should fix that issue!